### PR TITLE
Fix 'formatMoney is not defined' error

### DIFF
--- a/js/public_price_set_form.js
+++ b/js/public_price_set_form.js
@@ -109,6 +109,16 @@ CRM.percentagepricesetfield = {
   }
 };
 
+function formatMoney (amount, c, d, t){
+  var n = amount,
+  c = isNaN(c = Math.abs(c)) ? 2 : c,
+  d = d == undefined ? "," : d,
+  t = t == undefined ? "." : t, s = n < 0 ? "-" : "",
+  i = parseInt(n = Math.abs(+n || 0).toFixed(c)) + "",
+  j = (j = i.length) > 3 ? j % 3 : 0;
+  return s + (j ? i.substr(0, j) + t : "") + i.substr(j).replace(/(\d{3})(?=\d)/g, "$1" + t) + (c ? d + Math.abs(n - i).toFixed(c).slice(2) : "");
+};
+
 cj(function() {
   // Store the state of the checkbox, so we can restore it later.
   CRM.percentagepricesetfield.storePercentageState();


### PR DESCRIPTION
We've noticed the following error on few installs(mostly non drupal sites) using this extension. 

![image](https://user-images.githubusercontent.com/5929648/81169107-e4e09f00-8fb5-11ea-85bc-5e6289697245.png)

Not sure what exactly causes this but this PR includes the same function defined in templates//CRM/Contribute/Form/Contribution.tpl in this ext so that it is not dependent on core file anymore.