### PR TITLE
fix uncaught reference js error for formatMoney

### DIFF
--- a/js/public_price_set_form.js
+++ b/js/public_price_set_form.js
@@ -105,7 +105,7 @@ CRM.percentagepricesetfield = {
       currency_separator = separator;
     }
 
-    return formatMoney(finalTotal, 2, currency_separator, thousandMarker);
+    return CRM.formatMoney(finalTotal, 2, currency_separator, thousandMarker);
   }
 };
 


### PR DESCRIPTION
Hey!!!

When using this extension with CiviCRM 5.24.3 I got a "Uncaught ReferenceError: formatMoney is not defined" javascript error in the console (see screenshot below) this pr fixes that error.

![uncaughtReferenceError](https://user-images.githubusercontent.com/11323624/81186480-d62bc500-8f80-11ea-8f09-c2689f988e8a.png)

