### PR TITLE
Fix currency display on total amount

### DIFF
--- a/js/public_price_set_form.js
+++ b/js/public_price_set_form.js
@@ -77,13 +77,13 @@ CRM.percentagepricesetfield = {
 
   /**
    * Format amount as money.
-   * 
+   *
    * This function copied from CiviCRM's templates/CRM/Price/Form/Calculate.tpl in version 5.20.0
    * (https://lab.civicrm.org/dev/core/-/blob/5.20.0/templates/CRM/Price/Form/Calculate.tpl#L192)
-   * then modified with non-functional changes to meet civilint's jshint criteria. 
+   * then modified with non-functional changes to meet civilint's jshint criteria.
    * Also modified by renaming variables with more  descriptive names (original code
    * relied on variables with names like c, d, t, j, etc.)
-   * 
+   *
    * CRM.percentagepricesetfield.formatMoney(finalTotal, 2, currency_separator, thousandMarker);
    */
   formatMoney: function formatMoney(amount, precision, currencySeparator, thousandsMarker){
@@ -94,7 +94,7 @@ CRM.percentagepricesetfield = {
     // Unsure of the  meaning of 'i' here; todo: figure  this out and rename for more readable code.
     var i = parseInt(amount = Math.abs(+amount || 0).toFixed(precision)) + "";
     thousandsSplitLength = (thousandsSplitLength = i.length) > 3 ? thousandsSplitLength % 3 : 0;
-        
+
     return negativeMarker + (thousandsSplitLength ? i.substr(0, thousandsSplitLength) + thousandsMarker : "") + i.substr(thousandsSplitLength).replace(/(\d{3})(?=\d)/g, "$1" + thousandsMarker) + (precision ? currencySeparator + Math.abs(amount - i).toFixed(precision).slice(2) : "");
   },
 
@@ -170,7 +170,7 @@ cj(function() {
     // So if  we still don't have a value for monetarySymbol, try getting
     // the first non-space string in the pricevalue div (this is thought to be
     // more likely to work in cases of multi-character symbols (e.g. "Lek")
-    CRM.percentagepricesetfield.monetarySymbol = cj('#pricevalue').html().split(' ')[0];
+    CRM.percentagepricesetfield.monetarySymbol = cj('#pricevalue').html().match(/[\D]*/)[0];
   }
 
   // Add our function update-plus-percentage, as an event handler for all


### PR DESCRIPTION
Experienced this on Joomla + CiviCRM 5.24.6

The currency symbol display on the calculated total amount is not working when the amount is displayed as eg `$100` instead of `$ 100`(with space). I think the latter is the default display by civicrm? But in some cases(non drupal) or maybe due to theme enabled on the site, the total amount is displayed without the space between the symbol and the amount. 

The ext code depends on the "whitespace" and then splits the currency from the amount and prepends it to the calculated total. This PR modifies it and retrieves the currency using a regex that matches everything before a numeric value. This value in our case should only be the currency symbol?

Before the patch -

<img width="223" alt="Screenshot 2020-05-07 at 5 36 42 PM" src="https://user-images.githubusercontent.com/5929648/81397490-1176f100-9145-11ea-94c3-d11003bb06a7.png">

After -

<img width="175" alt="Screenshot 2020-05-07 at 5 37 12 PM" src="https://user-images.githubusercontent.com/5929648/81397503-16d43b80-9145-11ea-88d4-64b9c7b0a50d.png">
