### PR TITLE
Only run altercontent on forms that we are active on

### DIFF
--- a/percentagepricesetfield.php
+++ b/percentagepricesetfield.php
@@ -208,6 +208,25 @@ function percentagepricesetfield_civicrm_alterSettingsFolders(&$metaDataFolders 
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterContent
  */
 function percentagepricesetfield_civicrm_alterContent(&$content, $context, $tplName, &$object) {
+  if ($context !== 'form') {
+    return;
+  }
+  if (!in_array(
+    get_class($object),
+    [
+      'CRM_Price_Form_Field',
+      'CRM_Event_Form_ParticipantFeeSelection',
+      'CRM_Event_Form_Registration_Register',
+      'CRM_Contribute_Form_Contribution_Main',
+      'CRM_Contribute_Form_Contribution',
+      'CRM_Event_Form_Participant',
+      'CRM_Event_Form_Registration_AdditionalParticipant',
+      'CRM_Price_Form_Preview',
+    ])
+  ) {
+    return;
+  }
+
   $args = func_get_args();
   $args['_GET'] = $_GET;
   if ($func = call_user_func_array('_percentagepricesetfield_get_content_pricesetid_function', $args)) {


### PR DESCRIPTION
I was seeing an error in the javascript console on the contribution confirm form. From reading the code I see that altercontent is run on *all* forms. But it should only be running on forms that percentagepricesetfield is actually doing something - eg. contribution main form.