### PR TITLE
fix array key for PHP 8 compatibility

### DIFF
--- a/percentagepricesetfield.php
+++ b/percentagepricesetfield.php
@@ -209,7 +209,7 @@ function percentagepricesetfield_civicrm_alterSettingsFolders(&$metaDataFolders 
  */
 function percentagepricesetfield_civicrm_alterContent(&$content, $context, $tplName, &$object) {
   $args = func_get_args();
-  $args['_GET'] = $_GET;
+  $args['_get'] = $_GET;
   if ($func = call_user_func_array('_percentagepricesetfield_get_content_pricesetid_function', $args)) {
     if (function_exists($func)) {
       $price_set_id = call_user_func_array($func, $args);


### PR DESCRIPTION
This extension crashes on PHP 8.0 with:
```
Error: Unknown named parameter $_GET in percentagepricesetfield_civicrm_alterContent()
```

The reason is line 213 uses `call_user_func_array`.  The [PHP docs](https://www.php.net/manual/en/function.call-user-func-array.php) show a changelog for this function: 
```
8.0.0 | args keys will now be interpreted as parameter names, instead of being silently ignored.
```

The function signature of the called function is:
```
function _percentagepricesetfield_get_content_pricesetid_function($content, $context, $tplName, $object, $_get) {
```

While all the other elements of `$args` use an indexed array, $args['_GET'] has a named array key, and it doesn't match the function signature (which uses `$_get`, not `$_GET`).

I'm also happy to submit a second PR to not access `$_GET` directly, and use `CRM_Utils_Request`, but I wanted to keep the scope of this PR limited to fixing the critical issue.