### PR TITLE
Fix #64: Additional $1 charged when switched to pay later

### DIFF
--- a/js/public_price_set_form.js
+++ b/js/public_price_set_form.js
@@ -104,12 +104,6 @@ CRM.percentagepricesetfield = {
 
     var finalTotal;
     if (cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked')) {
-      // At this point, baseTotal includes the amount (presumably $1) of the percentage checkbox,
-      // so we should subtract that amount for an accurate baseTotal that includes
-      // only the other selected price fields.
-      var percentageCheckboxAmount = cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).data('line_raw_total');
-      baseTotal -= percentageCheckboxAmount;
-      
       // Calculate the appropriate percentage.
       var percentage = CRM.vars.percentagepricesetfield.percentage;
       var extra = (baseTotal*percentage/100);

--- a/percentagepricesetfield.php
+++ b/percentagepricesetfield.php
@@ -496,7 +496,11 @@ function _percentagepricesetfield_buildForm_public_price_set_form($form) {
     // JavaScript to auto-calculate the total (see
     // CRM/Price/Form/Calculate.tpl).
     // e.g., ["30","20||"]: change "20" to "0".
-    $element->_attributes['price'] = preg_replace('/(\["[^"]+",")[^|]+(\|.+)$/', '${1}0${2}', $element->_attributes['price']);
+    // e.g., [30,"20||"]: change "20" to "0".
+    //   (Note: newer civicrm versions omit the double-quotes around the first value e.g. 30)
+    $priceAttribute = $element->_attributes['price'];
+    $newPriceAttribute = preg_replace('/(\["?[^"]+"?,")[^|]+(\|.+)$/', '${1}0${2}', $priceAttribute);
+    $element->_attributes['price'] = $newPriceAttribute;
     $element_id = $field->_name . '_' . $element->_attributes['id'];
 
     // Store $element_id in the form so we can easily access it elsewhere.


### PR DESCRIPTION
Compared with #65, this fix gets more to the heart of the matter, which is this:

The extension (as of current `master` branch) is doing _extra unnecessary work_:

A. In the buildForm hook, it aims to set the 'percentage' checkbox "price/amount" to "0" (this is the buggy part as of current CiviCRM versions.)
B. Then, in `public_price_set_form.js` it does some manual work to subtract the checkbox amount from the calculated total, when the appropriate payment method is selected (in the case of #64, that means "pay later").  This is actually not needed, if the buildForm hook were doing its job and setting the checkbox price to "0".

This PR does 2 things:
1. Correct the bug mentioned in "A".
2. Remove the redundant/needless "subtract 0 from total" logic in the JS, mentioend in "B".

**More on the bug in "A":**

- Older CiviCRM versions set a 'price' attribute on checkbox fields like `["30","20||"]`
- Newer civicrm versions set that same attribute like `[30,"20||"]` (not the missing double-quotes around `30`.
- As a result, the regex in the buildForm hook was not making the required changes.
- This PR corrects that regex by expecting the double-quotes around the first value (e.g. `30`) to be optional.