### PR TITLE
[DRAFT][REF] Extract buildForm for checkbox into its own function

### DIFF
--- a/js/admin_price_field.js
+++ b/js/admin_price_field.js
@@ -13,12 +13,7 @@ cj(function($) {
     var html_type_name = cj('#html_type').val();
     // Call the original event listener.
     percentagepricesetfield_option_html_type_original(form);
-    if (html_type_name == 'CheckBox') {
-      cj("#percentagepricesetfield-block").show();
-    }
-    else {
-      cj("#percentagepricesetfield-block").hide();
-    }
+    cj("#percentagepricesetfield-block").show();
     is_percentagepricesetfield_change();
   };
 
@@ -41,14 +36,10 @@ cj(function($) {
 
   /**
    * OnChange handler for is_percentagepricesetfield checkbox.
-   * If html_type field is "CheckBox", show and hide some relevant sections,
-   * depending on whether the is_percentagepricesetfield checkbox is checked.
+   * Show and hide some relevant sections, depending on whether the
+   * is_percentagepricesetfield checkbox is checked.
    */
   var is_percentagepricesetfield_change = function() {
-    if (cj('#html_type').val() != 'CheckBox') {
-      return;
-    }
-
     var el_is_percentagepricesetfield = cj('input#is_percentagepricesetfield');
     if (
       (el_is_percentagepricesetfield.attr('type') == 'checkbox' && el_is_percentagepricesetfield.prop('checked')) ||

--- a/js/public_price_set_form.js
+++ b/js/public_price_set_form.js
@@ -13,7 +13,12 @@ CRM.percentagepricesetfield = {
   originalCalculateTotalFee: window.calculateTotalFee,
 
   storePercentageState: function storePercentageState() {
-    CRM.percentagepricesetfield.is_percentage = cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked');
+    var field = cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id);
+    if (field.attr('type') === 'checkbox') {
+      CRM.percentagepricesetfield.is_percentage = field.prop('checked');
+    } else if (field.attr('type') === 'text') {
+      CRM.percentagepricesetfield.is_percentage = Boolean(field.val());
+    }
   },
 
   /**
@@ -30,20 +35,20 @@ CRM.percentagepricesetfield = {
     if (CRM.vars.percentagepricesetfield.disable_payment_methods[selected_payment_method]) {
 
       // Hide the option.
-      cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).closest('.crm-section').hide();
+      cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).closest('.crm-section').hide();
       // Store the state of the checkbox, so we can restore it later.
       CRM.percentagepricesetfield.storePercentageState();
       // Un-check the checkbox; we have to actually uncheck it, because it's
       // a Price Set Field and will be treated as a line item if checked.
-      cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked', false);
+      cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).prop('checked', false);
     }
     else {
 
       // Restore the previous state of the percentage checkbox.
-      cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked', CRM.percentagepricesetfield.isPercentage());
+      cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).prop('checked', CRM.percentagepricesetfield.isPercentage());
       // Dispaly the option again.
       if (!CRM.vars.percentagepricesetfield.hide_and_force) {
-        cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).closest('.crm-section').show();
+        cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).closest('.crm-section').show();
       }
     }
     // Re-calculate the total-with-percentage; in the lines above, we manipulated
@@ -103,7 +108,7 @@ CRM.percentagepricesetfield = {
     }
 
     var finalTotal;
-    if (cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked')) {
+    if (CRM.percentagepricesetfield.is_percentage) {
       // Calculate the appropriate percentage.
       var percentage = CRM.vars.percentagepricesetfield.percentage;
       var extra = (baseTotal*percentage/100);
@@ -132,8 +137,8 @@ cj(function() {
 
   if (CRM.vars.percentagepricesetfield.hide_and_force) {
     // Hide and force if so configured.
-    cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked', true);
-    cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).closest('.crm-section').hide();
+    cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).prop('checked', true);
+    cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).closest('.crm-section').hide();
   }
 
   // Add an onChange handler for all of the payment method options.
@@ -189,7 +194,7 @@ cj(function() {
   CRM.percentagepricesetfield.changePaymentProcessor();
 
   // Add an event handler to set is_percentage any time the checkbox is manually changed.
-  cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).change(function(){
-    CRM.percentagepricesetfield.is_percentage = cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked');
+  cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).change(function(){
+    CRM.percentagepricesetfield.storePercentageState();
   });
 });

--- a/percentagepricesetfield.php
+++ b/percentagepricesetfield.php
@@ -484,32 +484,15 @@ function _percentagepricesetfield_buildForm_public_price_set_form($form) {
   $field_id = _percentagepricesetfield_get_form_percentage_field_id($form);
   if ($field_id) {
     $field = & $form->_elements[$form->_elementIndex["price_{$field_id}"]];
-    // Get a reference to the last element in the $field->_elements array.
-    end($field->_elements);
-    $element = & $field->_elements[key($field->_elements)];
-    // Use the field label as the label for this checkbox element.
-    $element->_text = $field->_label;
-    // Set this checkbox's "price" to 0. This allows us to avoid having
-    // this checkbox affect that calculation, and we'll use our  own
-    // JavaScript to adjust the total based on the percentage. CiviCRM
-    // uses a custom format for this attribute, parsing it later in
-    // JavaScript to auto-calculate the total (see
-    // CRM/Price/Form/Calculate.tpl).
-    // e.g., ["30","20||"]: change "20" to "0".
-    // e.g., [30,"20||"]: change "20" to "0".
-    //   (Note: newer civicrm versions omit the double-quotes around the first value e.g. 30)
-    $priceAttribute = $element->_attributes['price'];
-    $newPriceAttribute = preg_replace('/(\["?[^"]+"?,")[^|]+(\|.+)$/', '${1}0${2}', $priceAttribute);
-    $element->_attributes['price'] = $newPriceAttribute;
-    $element_id = $field->_name . '_' . $element->_attributes['id'];
+    // Modify the percentage field to work as a percentage field.
+    switch (get_class($field)) {
+      case 'HTML_QuickForm_group':
+        _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form, $field, $field_id);
+        break;
 
-    // Store $element_id in the form so we can easily access it elsewhere.
-    $form->_percentage_checkbox_id = $element_id;
-
-    // Remove this field's label (we copied it to the checkbox itself a few lines
-    // above.
-    $field->_label = '';
-
+      case 'HTML_QuickForm_text':
+        break;
+    }
     // If disable-per-payment-method, we must ignore any "Required" setting for
     // the percentage field.
     // (https://github.com/twomice/com.joineryhq.percentagepricesetfield/issues/19)
@@ -521,6 +504,30 @@ function _percentagepricesetfield_buildForm_public_price_set_form($form) {
       }
     }
   }
+}
+
+function _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form, $field, $field_id) {
+  // Get a reference to the last element in the $field->_elements array.
+  end($field->_elements);
+  $element = & $field->_elements[key($field->_elements)];
+  // Use the field label as the label for this checkbox element.
+  $element->_text = $field->_label;
+  // Set this checkbox's "price" to 0. This allows us to avoid having
+  // this checkbox affect that calculation, and we'll use our  own
+  // JavaScript to adjust the total based on the percentage. CiviCRM
+  // uses a custom format for this attribute, parsing it later in
+  // JavaScript to auto-calculate the total (see
+  // CRM/Price/Form/Calculate.tpl).
+  // e.g., ["30","20||"]: change "20" to "0".
+  // e.g., [30,"20||"]: change "20" to "0".
+  //   (Note: newer civicrm versions omit the double-quotes around the first value e.g. 30)
+  $priceAttribute = $element->_attributes['price'];
+  $newPriceAttribute = preg_replace('/(\["?[^"]+"?,")[^|]+(\|.+)$/', '${1}0${2}', $priceAttribute);
+  $element->_attributes['price'] = $newPriceAttribute;
+
+  // Remove this field's label (we copied it to the checkbox itself a few lines
+  // above.
+  $field->_label = '';
 }
 
 /**

--- a/percentagepricesetfield.php
+++ b/percentagepricesetfield.php
@@ -177,22 +177,30 @@ function percentagepricesetfield_civicrm_alterContent(&$content, $context, $tplN
       return;
     }
     $field_id = array_pop($field_ids);
-
-    // This checkbox field should have exactly one option. We need that option
-    // value because the checkbox element's "id" attribute will be
+    // I assume $object isn't always populated or we'd use that instead?
+    $formObject = $args[3];
+    $field_type = $formObject->_priceSet['fields'][$field_id]['html_type'];
+    // This field should have exactly one price field value. We need that
+    // value for tax rates, and because the "id" attribute for non-sliders will be
     // "price_[field_id]_[field_value]".
     $field_value = _percentagepricesetfield_get_field_value($field_id);
-    if (!$field_value_id = CRM_Utils_Array::value('id', $field_value)) {
+    $field_value_id = $field_value['id'] ?? FALSE;
+    if (!$field_value_id) {
       return;
     }
+    if ($field_type === 'Text') {
+      $percentage_field_id = "price_{$field_id}";
+    }
+    else {
+      $percentage_field_id = "price_{$field_id}_{$field_value_id}";
+    }
 
-    $formObject = $args[3];
     $taxRate = $formObject->_priceSet['fields'][$field_id]['options'][$field_value_id]['tax_rate'];
     // Insert our JavaScript code and variables.
     $vars = array(
       'percentage' => _percentagepricesetfield_get_percentage($price_set_id),
       'tax_rate' => $taxRate,
-      'percentage_checkbox_id' => "price_{$field_id}_{$field_value_id}",
+      'percentage_field_id' => $percentage_field_id,
       'hide_and_force' => (int) ($allow_hide_and_force && _percentagepricesetfield_get_setting_value($field_id, 'hide_and_force')),
       'is_default' => _percentagepricesetfield_get_setting_value($field_id, 'is_default'),
       'disable_payment_methods' => _percentagepricesetfield_get_setting_value($field_id, 'disable_payment_methods'),
@@ -487,10 +495,17 @@ function _percentagepricesetfield_buildForm_public_price_set_form($form) {
     // Modify the percentage field to work as a percentage field.
     switch (get_class($field)) {
       case 'HTML_QuickForm_group':
-        _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form, $field, $field_id);
+        // Get a reference to the last element in the $field->_elements array.
+        end($field->_elements);
+        $element = & $field->_elements[key($field->_elements)];
+        // Use the field label as the label for this checkbox element.
+        $element->_text = $field->_label;
+        $field->_label = '';
+        $element->_attributes['price'] = _percentagepricesetfield_fix_price_attribute($element->_attributes['price']);
         break;
 
       case 'HTML_QuickForm_text':
+        $field->_attributes['price'] = _percentagepricesetfield_fix_price_attribute($field->_attributes['price']);
         break;
     }
     // If disable-per-payment-method, we must ignore any "Required" setting for
@@ -506,14 +521,9 @@ function _percentagepricesetfield_buildForm_public_price_set_form($form) {
   }
 }
 
-function _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form, $field, $field_id) {
-  // Get a reference to the last element in the $field->_elements array.
-  end($field->_elements);
-  $element = & $field->_elements[key($field->_elements)];
-  // Use the field label as the label for this checkbox element.
-  $element->_text = $field->_label;
-  // Set this checkbox's "price" to 0. This allows us to avoid having
-  // this checkbox affect that calculation, and we'll use our  own
+function _percentagepricesetfield_fix_price_attribute(string $priceAttribute): string {
+  // Set this element's "price" to 0. This allows us to avoid having
+  // this element affect that calculation, and we'll use our  own
   // JavaScript to adjust the total based on the percentage. CiviCRM
   // uses a custom format for this attribute, parsing it later in
   // JavaScript to auto-calculate the total (see
@@ -521,13 +531,8 @@ function _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form
   // e.g., ["30","20||"]: change "20" to "0".
   // e.g., [30,"20||"]: change "20" to "0".
   //   (Note: newer civicrm versions omit the double-quotes around the first value e.g. 30)
-  $priceAttribute = $element->_attributes['price'];
   $newPriceAttribute = preg_replace('/(\["?[^"]+"?,")[^|]+(\|.+)$/', '${1}0${2}', $priceAttribute);
-  $element->_attributes['price'] = $newPriceAttribute;
-
-  // Remove this field's label (we copied it to the checkbox itself a few lines
-  // above.
-  $field->_label = '';
+  return $newPriceAttribute;
 }
 
 /**
@@ -590,7 +595,7 @@ function _percentagepricesetfield_buildForm_AdminPriceField(&$form) {
   }
 
   // On submit, whether new or existing field:
-  if ($form->_flagSubmitted && $form->_submitValues['html_type'] == 'CheckBox' && $form->_submitValues['is_percentagepricesetfield']) {
+  if ($form->_flagSubmitted && $form->_submitValues['is_percentagepricesetfield']) {
     // Remove the Required setting if the "disable for payment methods" is in use.
     if (!empty(CRM_Utils_Array::value('percentagepricesetfield_disable_payment_methods', $form->_submitValues))) {
       $form->_submitValues['is_required'] = 0;


### PR DESCRIPTION
`_percentagepricesetfield_buildForm_public_price_set_form()` will have different behaviors depending on the element type, so I'm extracting the checkbox-specific code into its own function.

It's a straight extraction, except I get this message both before and after extraction on PHP 8.3:
```
User deprecated function: attempt to set invalid property :_percentage_checkbox_id Caller: ::_percentagepricesetfield_buildForm_public_price_set_form in CRM_Core_Error::deprecatedWarning() (line 1144 of /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Error.php).
```

`_percentage_checkbox_id` isn't referenced anywhere else in the code, so I removed it. The percentage price ID is passed to JS in the `alterContent` hook.