### PR TITLE
[DRAFT} Slider and free entry implementation

### DIFF
--- a/CRM/Percentagepricesetfield/Upgrader.php
+++ b/CRM/Percentagepricesetfield/Upgrader.php
@@ -147,6 +147,22 @@ class CRM_Percentagepricesetfield_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_1104() {
+    // Note: Do NOT copy/paste this for future schema changes - in Civi 6.2+ you can use `E::schema->alterSchemaField()`.
+    $this->ctx->log->info('Applying update 1104');
+
+    $this->ctx->log->info('Add column for percentage field settings.');
+    if (!CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_percentagepricesetfield', 'slider_min')) {
+      CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_percentagepricesetfield ADD COLUMN is_slider tinyint(4) NOT NULL DEFAULT 1 COMMENT 'Display as slider'");
+      CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_percentagepricesetfield ADD COLUMN slider_min int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'Minimum percent for slider'");
+      CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_percentagepricesetfield ADD COLUMN slider_max int(10) unsigned NOT NULL DEFAULT 100 COMMENT 'Maximum percent for slider'");
+      CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_percentagepricesetfield ADD COLUMN slider_default int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'Default value for slider'");
+      CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_percentagepricesetfield ADD COLUMN slider_step int(10) unsigned NOT NULL DEFAULT 1 COMMENT 'Step for slider'");
+      CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_percentagepricesetfield ADD COLUMN slider_step_list varchar(255) NOT NULL DEFAULT '' COMMENT 'Step list for slider'");
+    }
+    return TRUE;
+  }
+
   /**
    * Example: Run an external SQL script
    *

--- a/js/admin_price_field.js
+++ b/js/admin_price_field.js
@@ -13,12 +13,7 @@ cj(function($) {
     var html_type_name = cj('#html_type').val();
     // Call the original event listener.
     percentagepricesetfield_option_html_type_original(form);
-    if (html_type_name == 'CheckBox') {
-      cj("#percentagepricesetfield-block").show();
-    }
-    else {
-      cj("#percentagepricesetfield-block").hide();
-    }
+    cj("#percentagepricesetfield-block").show();
     is_percentagepricesetfield_change();
   };
 
@@ -41,14 +36,10 @@ cj(function($) {
 
   /**
    * OnChange handler for is_percentagepricesetfield checkbox.
-   * If html_type field is "CheckBox", show and hide some relevant sections,
-   * depending on whether the is_percentagepricesetfield checkbox is checked.
+   * Show and hide some relevant sections, depending on whether the
+   * is_percentagepricesetfield checkbox is checked.
    */
   var is_percentagepricesetfield_change = function() {
-    if (cj('#html_type').val() != 'CheckBox') {
-      return;
-    }
-
     var el_is_percentagepricesetfield = cj('input#is_percentagepricesetfield');
     if (
       (el_is_percentagepricesetfield.attr('type') == 'checkbox' && el_is_percentagepricesetfield.prop('checked')) ||

--- a/js/admin_price_field.js
+++ b/js/admin_price_field.js
@@ -41,16 +41,23 @@ cj(function($) {
    */
   var is_percentagepricesetfield_change = function() {
     var el_is_percentagepricesetfield = cj('input#is_percentagepricesetfield');
-    if (
-      (el_is_percentagepricesetfield.attr('type') == 'checkbox' && el_is_percentagepricesetfield.prop('checked')) ||
-      (el_is_percentagepricesetfield.attr('type') == 'hidden' && el_is_percentagepricesetfield.val() == 1)
-    ) {
+    var field_type = cj('select#html_type').val();
+    if (el_is_percentagepricesetfield.attr('type') == 'checkbox' && el_is_percentagepricesetfield.prop('checked')) {
       cj("#showoption").hide();
       cj("#optionsPerLine").hide();
       cj(".crm-price-field-form-block-is_display_amounts").hide();
       cj("#percentagepricesetfield_financial_type").show();
       cj("div#percentagepricesetfield-block table tbody.percentagepricesetfield_details").show();
       cj("div#percentagepricesetfield-block").addClass('percentagepricesetfield-highlight');
+      if (field_type == 'Text') {
+        cj('#tr-percentagepricesetfield_percentage').hide();
+        cj('#tr-percentagepricesetfield_is_slider').show();
+      }
+      else {
+        cj('#tr-percentagepricesetfield_percentage').show();
+        cj('#tr-percentagepricesetfield_is_slider').hide();
+        cj('#tr-percentagepricesetfield_is_slider').prop('checked', false);
+      }
     }
     else {
       cj("#showoption").show();
@@ -59,8 +66,34 @@ cj(function($) {
       cj("#percentagepricesetfield_financial_type").hide();
       cj("div#percentagepricesetfield-block table tbody.percentagepricesetfield_details").hide();
       cj("div#percentagepricesetfield-block").removeClass('percentagepricesetfield-highlight');
+      cj('#tr-percentagepricesetfield_is_slider').hide();
     }
+    is_slider_change();
   };
+
+  /**
+   * OnChange handler for is_slider checkbox.
+   * Show and hide some relevant sections, depending on whether the
+   * is_slider checkbox is checked.
+   */
+  var is_slider_change = function() {
+    var el_is_slider = cj('input#percentagepricesetfield_is_slider');
+    if (el_is_slider.attr('type') == 'checkbox' && el_is_slider.prop('checked') ||
+        el_is_slider.attr('type') == 'hidden' && el_is_slider.val() == 1) {
+      cj("#tr-percentagepricesetfield_slider_min").show();
+      cj("#tr-percentagepricesetfield_slider_max").show();
+      cj("#tr-percentagepricesetfield_slider_default").show();
+      cj("#tr-percentagepricesetfield_slider_step").show();
+      cj("#tr-percentagepricesetfield_slider_step_list").show();
+    }
+    else {
+      cj("#tr-percentagepricesetfield_slider_min").hide();
+      cj("#tr-percentagepricesetfield_slider_max").hide();
+      cj("#tr-percentagepricesetfield_slider_default").hide();
+      cj("#tr-percentagepricesetfield_slider_step").hide();
+      cj("#tr-percentagepricesetfield_slider_step_list").hide();
+    }
+  }
 
   var percentagepricesetfield_disable_payment_methods_change = function() {
     var msg_id = 'disable_payment_methods_message';
@@ -155,6 +188,8 @@ cj(function($) {
 
   // Add change handler for "is percentage" checkbox
   cj('input#is_percentagepricesetfield').change(is_percentagepricesetfield_change);
+  // Add change handler for "is slider" checkbox
+  cj('input#percentagepricesetfield_is_slider').change(is_slider_change);
 
   // Add change handler for "hide and force" checkbox
   cj('#percentagepricesetfield_hide_and_force').change(hide_and_force_change);

--- a/js/public_price_set_form.js
+++ b/js/public_price_set_form.js
@@ -13,7 +13,12 @@ CRM.percentagepricesetfield = {
   originalCalculateTotalFee: window.calculateTotalFee,
 
   storePercentageState: function storePercentageState() {
-    CRM.percentagepricesetfield.is_percentage = cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked');
+    var field = cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id);
+    if (field.attr('type') === 'checkbox') {
+      CRM.percentagepricesetfield.is_percentage = field.prop('checked');
+    } else if (field.attr('type') === 'text') {
+      CRM.percentagepricesetfield.is_percentage = Boolean(field.val());
+    }
   },
 
   /**
@@ -30,20 +35,20 @@ CRM.percentagepricesetfield = {
     if (CRM.vars.percentagepricesetfield.disable_payment_methods[selected_payment_method]) {
 
       // Hide the option.
-      cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).closest('.crm-section').hide();
+      cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).closest('.crm-section').hide();
       // Store the state of the checkbox, so we can restore it later.
       CRM.percentagepricesetfield.storePercentageState();
       // Un-check the checkbox; we have to actually uncheck it, because it's
       // a Price Set Field and will be treated as a line item if checked.
-      cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked', false);
+      cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).prop('checked', false);
     }
     else {
 
       // Restore the previous state of the percentage checkbox.
-      cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked', CRM.percentagepricesetfield.isPercentage());
+      cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).prop('checked', CRM.percentagepricesetfield.isPercentage());
       // Dispaly the option again.
       if (!CRM.vars.percentagepricesetfield.hide_and_force) {
-        cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).closest('.crm-section').show();
+        cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).closest('.crm-section').show();
       }
     }
     // Re-calculate the total-with-percentage; in the lines above, we manipulated
@@ -103,7 +108,7 @@ CRM.percentagepricesetfield = {
     }
 
     var finalTotal;
-    if (cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked')) {
+    if (CRM.percentagepricesetfield.is_percentage) {
       // Calculate the appropriate percentage.
       var percentage = CRM.vars.percentagepricesetfield.percentage;
       var extra = (baseTotal*percentage/100);
@@ -132,8 +137,8 @@ cj(function() {
 
   if (CRM.vars.percentagepricesetfield.hide_and_force) {
     // Hide and force if so configured.
-    cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked', true);
-    cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).closest('.crm-section').hide();
+    cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).prop('checked', true);
+    cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).closest('.crm-section').hide();
   }
 
   // Add an onChange handler for all of the payment method options.
@@ -189,7 +194,7 @@ cj(function() {
   CRM.percentagepricesetfield.changePaymentProcessor();
 
   // Add an event handler to set is_percentage any time the checkbox is manually changed.
-  cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).change(function(){
-    CRM.percentagepricesetfield.is_percentage = cj('#' + CRM.vars.percentagepricesetfield.percentage_checkbox_id).prop('checked');
+  cj('#' + CRM.vars.percentagepricesetfield.percentage_field_id).change(function(){
+    CRM.percentagepricesetfield.storePercentageState();
   });
 });

--- a/percentagepricesetfield.php
+++ b/percentagepricesetfield.php
@@ -484,32 +484,15 @@ function _percentagepricesetfield_buildForm_public_price_set_form($form) {
   $field_id = _percentagepricesetfield_get_form_percentage_field_id($form);
   if ($field_id) {
     $field = & $form->_elements[$form->_elementIndex["price_{$field_id}"]];
-    // Get a reference to the last element in the $field->_elements array.
-    end($field->_elements);
-    $element = & $field->_elements[key($field->_elements)];
-    // Use the field label as the label for this checkbox element.
-    $element->_text = $field->_label;
-    // Set this checkbox's "price" to 0. This allows us to avoid having
-    // this checkbox affect that calculation, and we'll use our  own
-    // JavaScript to adjust the total based on the percentage. CiviCRM
-    // uses a custom format for this attribute, parsing it later in
-    // JavaScript to auto-calculate the total (see
-    // CRM/Price/Form/Calculate.tpl).
-    // e.g., ["30","20||"]: change "20" to "0".
-    // e.g., [30,"20||"]: change "20" to "0".
-    //   (Note: newer civicrm versions omit the double-quotes around the first value e.g. 30)
-    $priceAttribute = $element->_attributes['price'];
-    $newPriceAttribute = preg_replace('/(\["?[^"]+"?,")[^|]+(\|.+)$/', '${1}0${2}', $priceAttribute);
-    $element->_attributes['price'] = $newPriceAttribute;
-    $element_id = $field->_name . '_' . $element->_attributes['id'];
+    // Modify the percentage field to work as a percentage field.
+    switch (get_class($field)) {
+      case 'HTML_QuickForm_group':
+        _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form, $field, $field_id);
+        break;
 
-    // Store $element_id in the form so we can easily access it elsewhere.
-    $form->_percentage_checkbox_id = $element_id;
-
-    // Remove this field's label (we copied it to the checkbox itself a few lines
-    // above.
-    $field->_label = '';
-
+      case 'HTML_QuickForm_text':
+        break;
+    }
     // If disable-per-payment-method, we must ignore any "Required" setting for
     // the percentage field.
     // (https://github.com/twomice/com.joineryhq.percentagepricesetfield/issues/19)
@@ -521,6 +504,30 @@ function _percentagepricesetfield_buildForm_public_price_set_form($form) {
       }
     }
   }
+}
+
+function _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form, $field, $field_id) {
+  // Get a reference to the last element in the $field->_elements array.
+  end($field->_elements);
+  $element = & $field->_elements[key($field->_elements)];
+  // Use the field label as the label for this checkbox element.
+  $element->_text = $field->_label;
+  // Set this checkbox's "price" to 0. This allows us to avoid having
+  // this checkbox affect that calculation, and we'll use our  own
+  // JavaScript to adjust the total based on the percentage. CiviCRM
+  // uses a custom format for this attribute, parsing it later in
+  // JavaScript to auto-calculate the total (see
+  // CRM/Price/Form/Calculate.tpl).
+  // e.g., ["30","20||"]: change "20" to "0".
+  // e.g., [30,"20||"]: change "20" to "0".
+  //   (Note: newer civicrm versions omit the double-quotes around the first value e.g. 30)
+  $priceAttribute = $element->_attributes['price'];
+  $newPriceAttribute = preg_replace('/(\["?[^"]+"?,")[^|]+(\|.+)$/', '${1}0${2}', $priceAttribute);
+  $element->_attributes['price'] = $newPriceAttribute;
+
+  // Remove this field's label (we copied it to the checkbox itself a few lines
+  // above.
+  $field->_label = '';
 }
 
 /**

--- a/percentagepricesetfield.php
+++ b/percentagepricesetfield.php
@@ -177,22 +177,30 @@ function percentagepricesetfield_civicrm_alterContent(&$content, $context, $tplN
       return;
     }
     $field_id = array_pop($field_ids);
-
-    // This checkbox field should have exactly one option. We need that option
-    // value because the checkbox element's "id" attribute will be
+    // I assume $object isn't always populated or we'd use that instead?
+    $formObject = $args[3];
+    $field_type = $formObject->_priceSet['fields'][$field_id]['html_type'];
+    // This field should have exactly one price field value. We need that
+    // value for tax rates, and because the "id" attribute for non-sliders will be
     // "price_[field_id]_[field_value]".
     $field_value = _percentagepricesetfield_get_field_value($field_id);
-    if (!$field_value_id = CRM_Utils_Array::value('id', $field_value)) {
+    $field_value_id = $field_value['id'] ?? FALSE;
+    if (!$field_value_id) {
       return;
     }
+    if ($field_type === 'Text') {
+      $percentage_field_id = "price_{$field_id}";
+    }
+    else {
+      $percentage_field_id = "price_{$field_id}_{$field_value_id}";
+    }
 
-    $formObject = $args[3];
     $taxRate = $formObject->_priceSet['fields'][$field_id]['options'][$field_value_id]['tax_rate'];
     // Insert our JavaScript code and variables.
     $vars = array(
       'percentage' => _percentagepricesetfield_get_percentage($price_set_id),
       'tax_rate' => $taxRate,
-      'percentage_checkbox_id' => "price_{$field_id}_{$field_value_id}",
+      'percentage_field_id' => $percentage_field_id,
       'hide_and_force' => (int) ($allow_hide_and_force && _percentagepricesetfield_get_setting_value($field_id, 'hide_and_force')),
       'is_default' => _percentagepricesetfield_get_setting_value($field_id, 'is_default'),
       'disable_payment_methods' => _percentagepricesetfield_get_setting_value($field_id, 'disable_payment_methods'),
@@ -487,10 +495,17 @@ function _percentagepricesetfield_buildForm_public_price_set_form($form) {
     // Modify the percentage field to work as a percentage field.
     switch (get_class($field)) {
       case 'HTML_QuickForm_group':
-        _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form, $field, $field_id);
+        // Get a reference to the last element in the $field->_elements array.
+        end($field->_elements);
+        $element = & $field->_elements[key($field->_elements)];
+        // Use the field label as the label for this checkbox element.
+        $element->_text = $field->_label;
+        $field->_label = '';
+        $element->_attributes['price'] = _percentagepricesetfield_fix_price_attribute($element->_attributes['price']);
         break;
 
       case 'HTML_QuickForm_text':
+        $field->_attributes['price'] = _percentagepricesetfield_fix_price_attribute($field->_attributes['price']);
         break;
     }
     // If disable-per-payment-method, we must ignore any "Required" setting for
@@ -506,14 +521,9 @@ function _percentagepricesetfield_buildForm_public_price_set_form($form) {
   }
 }
 
-function _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form, $field, $field_id) {
-  // Get a reference to the last element in the $field->_elements array.
-  end($field->_elements);
-  $element = & $field->_elements[key($field->_elements)];
-  // Use the field label as the label for this checkbox element.
-  $element->_text = $field->_label;
-  // Set this checkbox's "price" to 0. This allows us to avoid having
-  // this checkbox affect that calculation, and we'll use our  own
+function _percentagepricesetfield_fix_price_attribute(string $priceAttribute): string {
+  // Set this element's "price" to 0. This allows us to avoid having
+  // this element affect that calculation, and we'll use our  own
   // JavaScript to adjust the total based on the percentage. CiviCRM
   // uses a custom format for this attribute, parsing it later in
   // JavaScript to auto-calculate the total (see
@@ -521,13 +531,8 @@ function _percentagepricesetfield_buildForm_public_price_set_form_checkbox($form
   // e.g., ["30","20||"]: change "20" to "0".
   // e.g., [30,"20||"]: change "20" to "0".
   //   (Note: newer civicrm versions omit the double-quotes around the first value e.g. 30)
-  $priceAttribute = $element->_attributes['price'];
   $newPriceAttribute = preg_replace('/(\["?[^"]+"?,")[^|]+(\|.+)$/', '${1}0${2}', $priceAttribute);
-  $element->_attributes['price'] = $newPriceAttribute;
-
-  // Remove this field's label (we copied it to the checkbox itself a few lines
-  // above.
-  $field->_label = '';
+  return $newPriceAttribute;
 }
 
 /**
@@ -590,7 +595,7 @@ function _percentagepricesetfield_buildForm_AdminPriceField(&$form) {
   }
 
   // On submit, whether new or existing field:
-  if ($form->_flagSubmitted && $form->_submitValues['html_type'] == 'CheckBox' && $form->_submitValues['is_percentagepricesetfield']) {
+  if ($form->_flagSubmitted && $form->_submitValues['is_percentagepricesetfield']) {
     // Remove the Required setting if the "disable for payment methods" is in use.
     if (!empty(CRM_Utils_Array::value('percentagepricesetfield_disable_payment_methods', $form->_submitValues))) {
       $form->_submitValues['is_required'] = 0;

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -16,6 +16,12 @@ CREATE TABLE IF NOT EXISTS `civicrm_percentagepricesetfield` (
   `apply_to_taxes` tinyint(4) DEFAULT '1' COMMENT 'Should this percentage be applied on top of taxes',
   `hide_and_force` tinyint(4) DEFAULT '0' COMMENT 'Should this percentage be applied always, and the field hidden',
   `disable_payment_methods` varchar(255) NOT NULL COMMENT 'Concatenated string of payment processor IDs',
+  `is_slider` tinyint(4) NOT NULL DEFAULT 1 COMMENT 'Display as slider',
+  `slider_min` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'Minimum percent for slider',
+  `slider_max` int(10) unsigned NOT NULL DEFAULT 100 COMMENT 'Maximum percent for slider',
+  'slider_default' int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'Default percent for slider',
+  `slider_step` int(10) unsigned NOT NULL DEFAULT 1 COMMENT 'Step for slider',
+  'slider_step_list' int(10) unsigned NOT NULL DEFAULT 1 COMMENT 'Step for slider',
   PRIMARY KEY (`id`),
   UNIQUE KEY `field_id` (`field_id`)
 ) ENGINE=InnoDB COMMENT='Price set fields marked as "additional percentage" type.';


### PR DESCRIPTION
Hi Alan,

I'll squash the commits, but wanted to tun this by you first.
The goal is to implement `Field calculates "Automatic Additional Percentage"` on all price field types.  This a) handles the "text/numeric" field, and also adds a "display as slider".  I intend to add radio button and select list functionality, but this PR was getting big. I'll follow up.

Here are the changes:
**Admin Form**:
* `Field calculates "Automatic Additional Percentage"` is now available on all price field types (will exclude radio/select for now, as per above).
* When the field is a checkbox, there should be zero difference from current behavior.
* Text/numeric fields display the "normal" percent options, plus a "Default percentage" input and  "Display as slider" checkbox.
* If "display as slider" is checked, there are various options for min, max, step, default and a "step list".
* The db schema has been updated to store these values.

**Front End**
* If you have a free-text entry percentage box, it works as expected, and uses the default set in the settings.
* If you have a slider, it converts the text box into a slider.  Min, Max and Step work as you expect.  "Step List" overrides "Step" and lets you define arbitrary points that represent the only choices for someone.

This looks big! But many changes are just the JS variable `percentage_checkbox_id`  to `percentage_field_id`.  And the fix I found when you're not including tax last week. Much of the rest is wrapped in `if` statements that cause them not to execute when a checkbox is in use.

I would guess you could install this on a dev site and see fairly easily that the original functionality is still present.

Jon
